### PR TITLE
feat: Add multi-team support with config.toml

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -68,10 +68,11 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-          type=sha,prefix={{branch}}-
+          type=sha,prefix=sha-
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image
+      id: build
       uses: docker/build-push-action@v5
       with:
         context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ WORKDIR /app
 COPY pyproject.toml ./
 
 # Install dependencies
-RUN pip install --upgrade pip && \
-    pip install --no-cache-dir .
+RUN pip install --upgrade pip --root-user-action=ignore && \
+    pip install --no-cache-dir . --root-user-action=ignore
 
 # Copy the rest of the source code
 COPY . .

--- a/README.md
+++ b/README.md
@@ -30,12 +30,15 @@ The scraper targets the specific HTML structure of the MLB injury page:
 
 ## Features
 
-- Scrapes New York Mets injury data from MLB.com in real-time
-- Handles special characters in player names (e.g., Dedniel Núñez)
-- Maintains chronological order (most recent injuries first)
-- Serves data via FastMCP server for AI tool integration
-- Provides multiple tools for different data views
-- Robust error handling and logging
+- **Multi-Team Support**: Scrapes injury data for all 30 MLB teams from MLB.com
+- **Real-time Data**: Fetches current injury information in real-time
+- **Team Configuration**: Configurable team URLs via `config.toml` file
+- **Special Character Support**: Handles special characters in player names (e.g., Dedniel Núñez)
+- **Chronological Order**: Maintains chronological order (most recent injuries first)
+- **MCP Server Integration**: Serves data via FastMCP server for AI tool integration
+- **Multiple Query Tools**: Provides various tools for different data views and team queries
+- **Robust Error Handling**: Comprehensive logging and graceful failure handling
+- **Backward Compatibility**: Legacy Mets-only methods still supported
 
 ## Installation
 
@@ -93,9 +96,33 @@ docker-compose up -d
 
 ### MCP Tools Available
 
-1. **get_mets_injuries()** - Get complete injury report with all fields
-2. **get_injury_summary()** - Get summary with counts and breakdowns  
-3. **search_player_injury(player_name)** - Search for specific player
+1. **get_team_injuries(team)** - Get complete injury report for any MLB team
+2. **get_available_teams()** - Get list of all supported MLB teams  
+3. **get_injury_summary(team)** - Get summary with counts and breakdowns for a team
+4. **search_player_injury(player_name, team)** - Search for specific player on a team
+5. **get_mets_injuries()** - Legacy method for Mets-only queries (backward compatibility)
+
+#### Team Keys
+Use these team keys when calling the tools:
+- `mets`, `yankees`, `dodgers`, `astros`, `braves`, `phillies`, `padres`, `orioles`
+- `rangers`, `marlins`, `giants`, `cubs`, `redsox`, `guardians`, `brewers`, `dbacks`
+- `tigers`, `cardinals`, `twins`, `mariners`, `bluejays`, `rays`, `nationals`, `reds`
+- `pirates`, `royals`, `angels`, `athletics`, `whitesox`, `rockies`
+
+#### Examples
+```python
+# Get Dodgers injuries
+get_team_injuries("dodgers")
+
+# Get Yankees injury summary  
+get_injury_summary("yankees")
+
+# Search for a player on the Mets
+search_player_injury("Pete Alonso", "mets")
+
+# Get all available teams
+get_available_teams()
+```
 
 ## MCP Configuration
 
@@ -118,6 +145,27 @@ Add to your Claude Desktop configuration file (`%APPDATA%\Claude\claude_desktop_
 ```
 
 **Important**: Replace `/path/to/your/project/mlb-injury-scraper` with the absolute path to your project directory.
+
+## Configuration
+
+The application uses a `config.toml` file to define MLB team URLs and metadata. This file contains:
+
+- **Team URLs**: Direct links to each team's injury report page on MLB.com
+- **Team Names**: Full team names (e.g., "New York Mets")
+- **Abbreviations**: Standard MLB team abbreviations (e.g., "NYM")
+
+### Adding New Teams
+
+To add support for additional teams, edit the `config.toml` file:
+
+```toml
+[teams.newteam]
+name = "New Team Name"
+url = "https://www.mlb.com/news/newteam-injuries-and-roster-moves"
+abbreviation = "NT"
+```
+
+The application will automatically pick up changes to the configuration file.
 
 ## Docker Images
 

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,154 @@
+# MLB Team Injury URLs Configuration
+# This file contains URLs for MLB team injury reports from MLB.com
+
+[teams]
+
+[teams.mets]
+name = "New York Mets"
+url = "https://www.mlb.com/news/mets-injuries-and-roster-moves"
+abbreviation = "NYM"
+
+[teams.yankees]
+name = "New York Yankees"
+url = "https://www.mlb.com/news/yankees-injuries-and-roster-moves"
+abbreviation = "NYY"
+
+[teams.dodgers]
+name = "Los Angeles Dodgers"
+url = "https://www.mlb.com/news/dodgers-injuries-and-roster-moves"
+abbreviation = "LAD"
+
+[teams.astros]
+name = "Houston Astros"
+url = "https://www.mlb.com/news/astros-injuries-and-roster-moves"
+abbreviation = "HOU"
+
+[teams.braves]
+name = "Atlanta Braves"
+url = "https://www.mlb.com/news/braves-injuries-and-roster-moves"
+abbreviation = "ATL"
+
+[teams.phillies]
+name = "Philadelphia Phillies"
+url = "https://www.mlb.com/news/phillies-injuries-and-roster-moves"
+abbreviation = "PHI"
+
+[teams.padres]
+name = "San Diego Padres"
+url = "https://www.mlb.com/news/padres-injuries-and-roster-moves"
+abbreviation = "SD"
+
+[teams.orioles]
+name = "Baltimore Orioles"
+url = "https://www.mlb.com/news/orioles-injuries-and-roster-moves"
+abbreviation = "BAL"
+
+[teams.rangers]
+name = "Texas Rangers"
+url = "https://www.mlb.com/news/rangers-injuries-and-roster-moves"
+abbreviation = "TEX"
+
+[teams.marlins]
+name = "Miami Marlins"
+url = "https://www.mlb.com/news/marlins-injuries-and-roster-moves"
+abbreviation = "MIA"
+
+[teams.giants]
+name = "San Francisco Giants"
+url = "https://www.mlb.com/news/giants-injuries-and-roster-moves"
+abbreviation = "SF"
+
+[teams.cubs]
+name = "Chicago Cubs"
+url = "https://www.mlb.com/news/cubs-injuries-and-roster-moves"
+abbreviation = "CHC"
+
+[teams.redsox]
+name = "Boston Red Sox"
+url = "https://www.mlb.com/news/red-sox-injuries-and-roster-moves"
+abbreviation = "BOS"
+
+[teams.guardians]
+name = "Cleveland Guardians"
+url = "https://www.mlb.com/news/guardians-injuries-and-roster-moves"
+abbreviation = "CLE"
+
+[teams.brewers]
+name = "Milwaukee Brewers"
+url = "https://www.mlb.com/news/brewers-injuries-and-roster-moves"
+abbreviation = "MIL"
+
+[teams.dbacks]
+name = "Arizona Diamondbacks"
+url = "https://www.mlb.com/news/d-backs-injuries-and-roster-moves"
+abbreviation = "AZ"
+
+[teams.tigers]
+name = "Detroit Tigers"
+url = "https://www.mlb.com/news/tigers-injuries-and-roster-moves"
+abbreviation = "DET"
+
+[teams.cardinals]
+name = "St. Louis Cardinals"
+url = "https://www.mlb.com/news/cardinals-injuries-and-roster-moves"
+abbreviation = "STL"
+
+[teams.twins]
+name = "Minnesota Twins"
+url = "https://www.mlb.com/news/twins-injuries-and-roster-moves"
+abbreviation = "MIN"
+
+[teams.mariners]
+name = "Seattle Mariners"
+url = "https://www.mlb.com/news/mariners-injuries-and-roster-moves"
+abbreviation = "SEA"
+
+[teams.bluejays]
+name = "Toronto Blue Jays"
+url = "https://www.mlb.com/news/blue-jays-injuries-and-roster-moves"
+abbreviation = "TOR"
+
+[teams.rays]
+name = "Tampa Bay Rays"
+url = "https://www.mlb.com/news/rays-injuries-and-roster-moves"
+abbreviation = "TB"
+
+[teams.nationals]
+name = "Washington Nationals"
+url = "https://www.mlb.com/news/nationals-injuries-and-roster-moves"
+abbreviation = "WSH"
+
+[teams.reds]
+name = "Cincinnati Reds"
+url = "https://www.mlb.com/news/reds-injuries-and-roster-moves"
+abbreviation = "CIN"
+
+[teams.pirates]
+name = "Pittsburgh Pirates"
+url = "https://www.mlb.com/news/pirates-injuries-and-roster-moves"
+abbreviation = "PIT"
+
+[teams.royals]
+name = "Kansas City Royals"
+url = "https://www.mlb.com/news/royals-injuries-and-roster-moves"
+abbreviation = "KC"
+
+[teams.angels]
+name = "Los Angeles Angels"
+url = "https://www.mlb.com/news/angels-injuries-and-roster-moves"
+abbreviation = "LAA"
+
+[teams.athletics]
+name = "Oakland Athletics"
+url = "https://www.mlb.com/news/athletics-injuries-and-roster-moves"
+abbreviation = "OAK"
+
+[teams.whitesox]
+name = "Chicago White Sox"
+url = "https://www.mlb.com/news/white-sox-injuries-and-roster-moves"
+abbreviation = "CWS"
+
+[teams.rockies]
+name = "Colorado Rockies"
+url = "https://www.mlb.com/news/rockies-injuries-and-roster-moves"
+abbreviation = "COL"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "fastmcp>=0.1.0",
     "pydantic>=2.0.0",
     "lxml>=4.9.0",
+    "tomli>=2.0.0; python_version<'3.11'",
 ]
 
 [build-system]

--- a/scripts/test_scraper.py
+++ b/scripts/test_scraper.py
@@ -16,60 +16,64 @@ def main():
     
     scraper = MLBInjuryScraper()
     
+    # Test available teams
+    print("\n=== Available Teams ===")
+    teams = scraper.get_available_teams()
+    print(f"Found {len(teams)} teams in configuration:")
+    for team_key in teams[:5]:  # Show first 5 teams
+        team_info = scraper.get_team_info(team_key)
+        if team_info:
+            print(f"  {team_key}: {team_info['name']} ({team_info['abbreviation']})")
+    if len(teams) > 5:
+        print(f"  ... and {len(teams) - 5} more teams")
+    
+    # Test teams to scrape
+    test_teams = ['mets', 'dodgers', 'yankees']
+    
+    for team in test_teams:
+        print(f"\n=== Testing {team.upper()} ===")
+        try:
+            injured_players = scraper.scrape_team_injuries(team)
+            
+            print(f"Found {len(injured_players)} injured players:")
+            print("-" * 50)
+            
+            for player in injured_players[:3]:  # Show first 3 players max
+                print(f"Player name: {player.name}")
+                print(f"Player position: {player.position}")
+                print(f"Injury: {player.injury}")
+                if player.il_date:
+                    print(f"IL date: {player.il_date}")
+                if player.expected_return:
+                    print(f"Expected return: {player.expected_return}")
+                if player.status:
+                    print(f"Status: {player.status}")
+                if player.last_updated:
+                    print(f"Last updated: {player.last_updated}")
+                print()  # Add blank line between players
+                print("-" * 50)
+            
+            if len(injured_players) > 3:
+                print(f"... and {len(injured_players) - 3} more injured players")
+            
+            if not injured_players:
+                print("No injury data found. This could mean:")
+                print("1. No players are currently injured")
+                print("2. The website structure has changed")
+                print("3. The page couldn't be accessed")
+                
+        except Exception as e:
+            print(f"Error testing {team} scraper: {e}")
+            import traceback
+            traceback.print_exc()
+    
+    # Test legacy method
+    print(f"\n=== Testing Legacy Mets Method ===")
     try:
         injured_players = scraper.scrape_mets_injuries()
-        
-        print(f"\nFound {len(injured_players)} injured players:")
-        print("-" * 50)
-        
-        for player in injured_players:
-            print(f"Player name: {player.name}")
-            print(f"Player position: {player.position}")
-            print(f"Injury: {player.injury}")
-            if player.il_date:
-                print(f"IL date: {player.il_date}")
-            if player.expected_return:
-                print(f"Expected return: {player.expected_return}")
-            if player.status:
-                print(f"Status: {player.status}")
-            if player.last_updated:
-                print(f"Last updated: {player.last_updated}")
-            print()  # Add blank line between players
-            print("-" * 50)
-        
-        if not injured_players:
-            print("No injury data found. This could mean:")
-            print("1. No players are currently injured")
-            print("2. The website structure has changed")
-            print("3. The page couldn't be accessed")
-            print("\nTrying to fetch the page directly to check...")
-            
-            # Debug: Try to fetch and show some page content
-            import requests
-            try:
-                response = requests.get("https://www.mlb.com/news/mets-injuries-and-roster-moves", timeout=10)
-                print(f"Response status: {response.status_code}")
-                if response.status_code == 200:
-                    from bs4 import BeautifulSoup
-                    soup = BeautifulSoup(response.content, 'html.parser')
-                    title = soup.find('title')
-                    if title:
-                        print(f"Page title: {title.get_text()}")
-                    
-                    # Show first few paragraphs
-                    paragraphs = soup.find_all('p')[:5]
-                    print(f"\nFirst few paragraphs ({len(paragraphs)}):")
-                    for i, p in enumerate(paragraphs):
-                        text = p.get_text().strip()
-                        if text:
-                            print(f"{i+1}: {text[:200]}...")
-            except Exception as debug_e:
-                print(f"Debug fetch failed: {debug_e}")
-            
+        print(f"Legacy method found {len(injured_players)} injured Mets players")
     except Exception as e:
-        print(f"Error testing scraper: {e}")
-        import traceback
-        traceback.print_exc()
+        print(f"Error testing legacy method: {e}")
 
 if __name__ == "__main__":
     main()

--- a/server.py
+++ b/server.py
@@ -17,10 +17,24 @@ mcp = FastMCP("MLB Injury Scraper")
 scraper = MLBInjuryScraper()
 
 @mcp.tool()
-def get_mets_injuries() -> List[Dict[str, Any]]:
-    """Get current New York Mets injury report with player details."""
+def get_team_injuries(team: str) -> List[Dict[str, Any]]:
+    """Get current injury report for any MLB team.
+    
+    Args:
+        team: Team key (e.g., 'mets', 'dodgers', 'yankees')
+    """
     try:
-        injured_players = scraper.scrape_mets_injuries()
+        injured_players = scraper.scrape_team_injuries(team.lower())
+        
+        if not injured_players:
+            # Check if team exists in config
+            available_teams = scraper.get_available_teams()
+            if team.lower() not in available_teams:
+                return [{
+                    "error": f"Team '{team}' not supported. Available teams: {', '.join(available_teams)}"
+                }]
+            else:
+                return [{"message": f"No injury data found for {team}"}]
         
         # Convert to dictionaries for JSON serialization
         result = []
@@ -35,18 +49,51 @@ def get_mets_injuries() -> List[Dict[str, Any]]:
                 "last_updated": player.last_updated
             })
         
-        logger.info(f"Retrieved {len(result)} injured players")
+        logger.info(f"Retrieved {len(result)} injured players for {team}")
         return result
         
     except Exception as e:
-        logger.error(f"Error getting Mets injuries: {e}")
-        return [{"error": f"Failed to retrieve injury data: {str(e)}"}]
+        logger.error(f"Error getting {team} injuries: {e}")
+        return [{"error": f"Failed to retrieve injury data for {team}: {str(e)}"}]
 
 @mcp.tool()
-def get_injury_summary() -> Dict[str, Any]:
-    """Get a summary of Mets injuries including counts by status."""
+def get_mets_injuries() -> List[Dict[str, Any]]:
+    """Get current New York Mets injury report with player details (legacy method)."""
+    return get_team_injuries('mets')
+
+@mcp.tool()
+def get_available_teams() -> Dict[str, Any]:
+    """Get list of all available MLB teams that can be queried."""
     try:
-        injured_players = scraper.scrape_mets_injuries()
+        teams = scraper.get_available_teams()
+        team_info = {}
+        
+        for team_key in teams:
+            info = scraper.get_team_info(team_key)
+            if info:
+                team_info[team_key] = {
+                    "name": info.get('name', team_key),
+                    "abbreviation": info.get('abbreviation', team_key.upper())
+                }
+        
+        return {
+            "total_teams": len(teams),
+            "teams": team_info
+        }
+        
+    except Exception as e:
+        logger.error(f"Error getting available teams: {e}")
+        return {"error": f"Failed to retrieve team list: {str(e)}"}
+
+@mcp.tool()
+def get_injury_summary(team: str = 'mets') -> Dict[str, Any]:
+    """Get a summary of team injuries including counts by status.
+    
+    Args:
+        team: Team key (e.g., 'mets', 'dodgers', 'yankees'). Defaults to 'mets'.
+    """
+    try:
+        injured_players = scraper.scrape_team_injuries(team.lower())
         
         total_injured = len(injured_players)
         status_counts = {}
@@ -64,14 +111,19 @@ def get_injury_summary() -> Dict[str, Any]:
         }
         
     except Exception as e:
-        logger.error(f"Error getting injury summary: {e}")
-        return {"error": f"Failed to retrieve injury summary: {str(e)}"}
+        logger.error(f"Error getting injury summary for {team}: {e}")
+        return {"error": f"Failed to retrieve injury summary for {team}: {str(e)}"}
 
 @mcp.tool()
-def search_player_injury(player_name: str) -> Dict[str, Any]:
-    """Search for a specific player's injury status."""
+def search_player_injury(player_name: str, team: str = 'mets') -> Dict[str, Any]:
+    """Search for a specific player's injury status.
+    
+    Args:
+        player_name: Name of the player to search for
+        team: Team key to search in (e.g., 'mets', 'dodgers', 'yankees'). Defaults to 'mets'.
+    """
     try:
-        injured_players = scraper.scrape_mets_injuries()
+        injured_players = scraper.scrape_team_injuries(team.lower())
         
         # Search for player (case-insensitive)
         player_name_lower = player_name.lower()
@@ -90,11 +142,11 @@ def search_player_injury(player_name: str) -> Dict[str, Any]:
         
         return {
             "found": False,
-            "message": f"No injury information found for player: {player_name}"
+            "message": f"No injury information found for player: {player_name} on team: {team}"
         }
         
     except Exception as e:
-        logger.error(f"Error searching for player {player_name}: {e}")
+        logger.error(f"Error searching for player {player_name} on team {team}: {e}")
         return {"error": f"Failed to search for player: {str(e)}"}
 
 def main():

--- a/uv.lock
+++ b/uv.lock
@@ -548,6 +548,7 @@ requires-dist = [
     { name = "lxml", specifier = ">=4.9.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "requests", specifier = ">=2.31.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add config.toml with URLs for all 30 MLB teams
- Update scraper.py to support any team via configuration
- Add new MCP tools: get_team_injuries(), get_available_teams()
- Update existing tools to accept team parameter with defaults
- Maintain backward compatibility with legacy Mets-only methods
- Fix Dockerfile pip root user warning
- Update tests to validate multi-team functionality
- Update documentation with new features and examples
- Add TOML dependency for configuration parsing