### PR TITLE
feat: Add HTTP/REST API and SSE streaming support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,12 @@ RUN chown -R appuser:appuser /app
 # Switch to non-root user
 USER appuser
 
-# Expose port (if needed for health checks)
+# Expose port for HTTP server
 EXPOSE 8000
 
-# Health check
+# Health check for HTTP mode
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import requests; requests.get('http://localhost:8000/health', timeout=5)" || exit 1
 
-CMD ["python", "server.py"]
+# Default to HTTP server mode, but allow override
+CMD ["python", "server.py", "--http"]

--- a/examples/http_client_example.py
+++ b/examples/http_client_example.py
@@ -1,0 +1,149 @@
+"""Example HTTP client for the MLB Injury Scraper API."""
+
+import asyncio
+import json
+import requests
+from typing import Dict, Any, List
+import httpx
+
+class MLBInjuryAPIClient:
+    """Client for the MLB Injury Scraper HTTP API."""
+    
+    def __init__(self, base_url: str = "http://localhost:8000"):
+        self.base_url = base_url.rstrip('/')
+        self.session = requests.Session()
+    
+    def health_check(self) -> Dict[str, Any]:
+        """Check if the API is healthy."""
+        response = self.session.get(f"{self.base_url}/health")
+        response.raise_for_status()
+        return response.json()
+    
+    def get_available_teams(self) -> Dict[str, Any]:
+        """Get all available teams."""
+        response = self.session.get(f"{self.base_url}/api/teams")
+        response.raise_for_status()
+        return response.json()
+    
+    def get_team_injuries(self, team: str) -> Dict[str, Any]:
+        """Get injuries for a specific team."""
+        response = self.session.get(f"{self.base_url}/api/teams/{team}/injuries")
+        response.raise_for_status()
+        return response.json()
+    
+    def get_injury_summary(self, team: str) -> Dict[str, Any]:
+        """Get injury summary for a team."""
+        response = self.session.get(f"{self.base_url}/api/teams/{team}/summary")
+        response.raise_for_status()
+        return response.json()
+    
+    def search_player(self, team: str, player_name: str) -> Dict[str, Any]:
+        """Search for a player on a team."""
+        response = self.session.get(f"{self.base_url}/api/teams/{team}/players/{player_name}")
+        response.raise_for_status()
+        return response.json()
+    
+    async def stream_team_injuries(self, team: str, interval: int = 30):
+        """Stream real-time injury updates via SSE."""
+        async with httpx.AsyncClient() as client:
+            url = f"{self.base_url}/api/teams/{team}/injuries/stream?interval={interval}"
+            async with client.stream("GET", url) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if line.startswith("data: "):
+                        data = line[6:]  # Remove "data: " prefix
+                        try:
+                            yield json.loads(data)
+                        except json.JSONDecodeError:
+                            continue
+
+def main():
+    """Example usage of the MLB Injury API client."""
+    client = MLBInjuryAPIClient()
+    
+    print("🏥 MLB Injury Scraper API Client Example")
+    print("=" * 50)
+    
+    try:
+        # Health check
+        print("\n1. Health Check:")
+        health = client.health_check()
+        print(f"   Status: {health['status']}")
+        
+        # Get available teams
+        print("\n2. Available Teams:")
+        teams_data = client.get_available_teams()
+        print(f"   Total teams: {teams_data['total_teams']}")
+        print("   Sample teams:")
+        for team_key, team_info in list(teams_data['teams'].items())[:5]:
+            print(f"     - {team_key}: {team_info['name']} ({team_info['abbreviation']})")
+        
+        # Test with specific teams
+        test_teams = ['mets', 'dodgers', 'yankees']
+        
+        for team in test_teams:
+            print(f"\n3. {team.upper()} Injuries:")
+            try:
+                injuries = client.get_team_injuries(team)
+                print(f"   Team: {injuries['team_name']}")
+                print(f"   Total injured: {injuries['total_injured']}")
+                
+                if injuries['players']:
+                    print("   Recent injuries:")
+                    for player in injuries['players'][:3]:  # Show first 3
+                        print(f"     - {player['name']} ({player['position']}): {player['injury']}")
+                
+                # Get summary
+                summary = client.get_injury_summary(team)
+                print(f"   Injury types: {len(summary['injury_type_breakdown'])}")
+                
+            except requests.exceptions.HTTPError as e:
+                print(f"   Error: {e}")
+        
+        # Search for a player
+        print("\n4. Player Search Example:")
+        try:
+            search_result = client.search_player('mets', 'Pete')
+            if search_result['found']:
+                player = search_result['player']
+                print(f"   Found: {player['name']} - {player['injury']}")
+            else:
+                print(f"   {search_result['message']}")
+        except requests.exceptions.HTTPError as e:
+            print(f"   Search error: {e}")
+        
+        print("\n5. SSE Stream Example:")
+        print("   To test real-time streaming, run:")
+        print("   python -c \"import asyncio; from examples.http_client_example import stream_example; asyncio.run(stream_example())\"")
+        
+    except requests.exceptions.ConnectionError:
+        print("❌ Could not connect to the API server.")
+        print("   Make sure the server is running with: python server.py --http")
+    except Exception as e:
+        print(f"❌ Error: {e}")
+
+async def stream_example():
+    """Example of streaming real-time updates."""
+    client = MLBInjuryAPIClient()
+    
+    print("🔄 Streaming Mets injuries (press Ctrl+C to stop)...")
+    try:
+        count = 0
+        async for update in client.stream_team_injuries('mets', interval=10):
+            count += 1
+            print(f"\n📡 Update #{count}:")
+            print(f"   Team: {update['team_name']}")
+            print(f"   Total injured: {update['total_injured']}")
+            print(f"   Timestamp: {update['timestamp']}")
+            
+            if count >= 3:  # Stop after 3 updates for demo
+                print("\n✅ Demo complete!")
+                break
+                
+    except KeyboardInterrupt:
+        print("\n🛑 Streaming stopped by user")
+    except Exception as e:
+        print(f"❌ Streaming error: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/http_server.py
+++ b/http_server.py
@@ -1,0 +1,332 @@
+"""HTTP/REST API server for MLB injury data with SSE support."""
+
+import asyncio
+import json
+import logging
+from typing import List, Dict, Any, Optional
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+import uvicorn
+from sse_starlette.sse import EventSourceResponse
+
+from scraper import MLBInjuryScraper, InjuredPlayer
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Global scraper instance
+scraper: Optional[MLBInjuryScraper] = None
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Initialize and cleanup the scraper."""
+    global scraper
+    scraper = MLBInjuryScraper()
+    logger.info("MLB Injury Scraper HTTP server started")
+    yield
+    logger.info("MLB Injury Scraper HTTP server shutting down")
+
+# Create FastAPI app
+app = FastAPI(
+    title="MLB Injury Scraper API",
+    description="REST API for MLB injury data with real-time updates",
+    version="1.0.0",
+    lifespan=lifespan
+)
+
+# Add CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Pydantic models for request/response
+class InjuredPlayerResponse(BaseModel):
+    name: str
+    position: str
+    injury: str
+    il_date: Optional[str] = None
+    expected_return: Optional[str] = None
+    status: Optional[str] = None
+    last_updated: Optional[str] = None
+
+class TeamInjuriesResponse(BaseModel):
+    team: str
+    team_name: str
+    total_injured: int
+    players: List[InjuredPlayerResponse]
+
+class InjurySummaryResponse(BaseModel):
+    team: str
+    total_injured_players: int
+    injury_type_breakdown: Dict[str, int]
+    last_updated: str
+
+class AvailableTeamsResponse(BaseModel):
+    total_teams: int
+    teams: Dict[str, Dict[str, str]]
+
+class PlayerSearchResponse(BaseModel):
+    found: bool
+    player: Optional[InjuredPlayerResponse] = None
+    message: Optional[str] = None
+
+# Health check endpoint
+@app.get("/health")
+async def health_check():
+    """Health check endpoint."""
+    return {"status": "healthy", "service": "mlb-injury-scraper"}
+
+# Get available teams
+@app.get("/api/teams", response_model=AvailableTeamsResponse)
+async def get_available_teams():
+    """Get list of all available MLB teams."""
+    try:
+        teams = scraper.get_available_teams()
+        team_info = {}
+        
+        for team_key in teams:
+            info = scraper.get_team_info(team_key)
+            if info:
+                team_info[team_key] = {
+                    "name": info.get('name', team_key),
+                    "abbreviation": info.get('abbreviation', team_key.upper())
+                }
+        
+        return AvailableTeamsResponse(
+            total_teams=len(teams),
+            teams=team_info
+        )
+        
+    except Exception as e:
+        logger.error(f"Error getting available teams: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve team list: {str(e)}")
+
+# Get team injuries
+@app.get("/api/teams/{team}/injuries", response_model=TeamInjuriesResponse)
+async def get_team_injuries(team: str):
+    """Get current injury report for a specific MLB team."""
+    try:
+        # Validate team exists
+        available_teams = scraper.get_available_teams()
+        if team.lower() not in available_teams:
+            raise HTTPException(
+                status_code=404, 
+                detail=f"Team '{team}' not supported. Available teams: {', '.join(available_teams)}"
+            )
+        
+        team_info = scraper.get_team_info(team.lower())
+        injured_players = scraper.scrape_team_injuries(team.lower())
+        
+        players = [
+            InjuredPlayerResponse(
+                name=player.name,
+                position=player.position,
+                injury=player.injury,
+                il_date=player.il_date,
+                expected_return=player.expected_return,
+                status=player.status,
+                last_updated=player.last_updated
+            )
+            for player in injured_players
+        ]
+        
+        return TeamInjuriesResponse(
+            team=team.lower(),
+            team_name=team_info.get('name', team) if team_info else team,
+            total_injured=len(players),
+            players=players
+        )
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting {team} injuries: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve injury data for {team}: {str(e)}")
+
+# Get injury summary
+@app.get("/api/teams/{team}/summary", response_model=InjurySummaryResponse)
+async def get_injury_summary(team: str):
+    """Get injury summary for a specific team."""
+    try:
+        # Validate team exists
+        available_teams = scraper.get_available_teams()
+        if team.lower() not in available_teams:
+            raise HTTPException(
+                status_code=404, 
+                detail=f"Team '{team}' not supported. Available teams: {', '.join(available_teams)}"
+            )
+        
+        injured_players = scraper.scrape_team_injuries(team.lower())
+        
+        total_injured = len(injured_players)
+        injury_types = {}
+        
+        for player in injured_players:
+            injury_type = player.injury
+            injury_types[injury_type] = injury_types.get(injury_type, 0) + 1
+        
+        return InjurySummaryResponse(
+            team=team.lower(),
+            total_injured_players=total_injured,
+            injury_type_breakdown=injury_types,
+            last_updated="Real-time data from MLB.com"
+        )
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting injury summary for {team}: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve injury summary for {team}: {str(e)}")
+
+# Search for player
+@app.get("/api/teams/{team}/players/{player_name}", response_model=PlayerSearchResponse)
+async def search_player_injury(team: str, player_name: str):
+    """Search for a specific player's injury status on a team."""
+    try:
+        # Validate team exists
+        available_teams = scraper.get_available_teams()
+        if team.lower() not in available_teams:
+            raise HTTPException(
+                status_code=404, 
+                detail=f"Team '{team}' not supported. Available teams: {', '.join(available_teams)}"
+            )
+        
+        injured_players = scraper.scrape_team_injuries(team.lower())
+        
+        # Search for player (case-insensitive)
+        player_name_lower = player_name.lower()
+        for player in injured_players:
+            if player_name_lower in player.name.lower():
+                return PlayerSearchResponse(
+                    found=True,
+                    player=InjuredPlayerResponse(
+                        name=player.name,
+                        position=player.position,
+                        injury=player.injury,
+                        il_date=player.il_date,
+                        expected_return=player.expected_return,
+                        status=player.status,
+                        last_updated=player.last_updated
+                    )
+                )
+        
+        return PlayerSearchResponse(
+            found=False,
+            message=f"No injury information found for player: {player_name} on team: {team}"
+        )
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error searching for player {player_name} on team {team}: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to search for player: {str(e)}")
+
+# SSE endpoint for real-time updates
+@app.get("/api/teams/{team}/injuries/stream")
+async def stream_team_injuries(team: str, interval: int = Query(30, ge=10, le=300)):
+    """Stream real-time injury updates for a team via Server-Sent Events."""
+    
+    async def generate_injury_updates():
+        """Generate injury updates at specified intervals."""
+        while True:
+            try:
+                # Validate team exists
+                available_teams = scraper.get_available_teams()
+                if team.lower() not in available_teams:
+                    yield {
+                        "event": "error",
+                        "data": json.dumps({
+                            "error": f"Team '{team}' not supported. Available teams: {', '.join(available_teams)}"
+                        })
+                    }
+                    break
+                
+                team_info = scraper.get_team_info(team.lower())
+                injured_players = scraper.scrape_team_injuries(team.lower())
+                
+                players_data = [
+                    {
+                        "name": player.name,
+                        "position": player.position,
+                        "injury": player.injury,
+                        "il_date": player.il_date,
+                        "expected_return": player.expected_return,
+                        "status": player.status,
+                        "last_updated": player.last_updated
+                    }
+                    for player in injured_players
+                ]
+                
+                update_data = {
+                    "team": team.lower(),
+                    "team_name": team_info.get('name', team) if team_info else team,
+                    "total_injured": len(players_data),
+                    "players": players_data,
+                    "timestamp": asyncio.get_event_loop().time()
+                }
+                
+                yield {
+                    "event": "injury_update",
+                    "data": json.dumps(update_data)
+                }
+                
+                await asyncio.sleep(interval)
+                
+            except Exception as e:
+                logger.error(f"Error in SSE stream for {team}: {e}")
+                yield {
+                    "event": "error",
+                    "data": json.dumps({"error": str(e)})
+                }
+                await asyncio.sleep(interval)
+    
+    return EventSourceResponse(generate_injury_updates())
+
+# Legacy endpoints for backward compatibility
+@app.get("/api/mets/injuries")
+async def get_mets_injuries():
+    """Legacy endpoint for Mets injuries (redirects to new API)."""
+    return await get_team_injuries("mets")
+
+# Root endpoint with API documentation
+@app.get("/")
+async def root():
+    """Root endpoint with API information."""
+    return {
+        "service": "MLB Injury Scraper API",
+        "version": "1.0.0",
+        "endpoints": {
+            "health": "/health",
+            "teams": "/api/teams",
+            "team_injuries": "/api/teams/{team}/injuries",
+            "injury_summary": "/api/teams/{team}/summary",
+            "player_search": "/api/teams/{team}/players/{player_name}",
+            "sse_stream": "/api/teams/{team}/injuries/stream?interval={seconds}",
+            "docs": "/docs",
+            "openapi": "/openapi.json"
+        },
+        "example_teams": ["mets", "dodgers", "yankees", "astros", "braves"]
+    }
+
+def run_http_server(host: str = "0.0.0.0", port: int = 8000, reload: bool = False):
+    """Run the HTTP server."""
+    logger.info(f"Starting MLB Injury Scraper HTTP server on {host}:{port}")
+    uvicorn.run(
+        "http_server:app",
+        host=host,
+        port=port,
+        reload=reload,
+        log_level="info"
+    )
+
+if __name__ == "__main__":
+    run_http_server()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,10 @@ dependencies = [
     "pydantic>=2.0.0",
     "lxml>=4.9.0",
     "tomli>=2.0.0; python_version<'3.11'",
+    "fastapi>=0.104.0",
+    "uvicorn>=0.24.0",
+    "sse-starlette>=1.6.0",
+    "httpx>=0.25.0",
 ]
 
 [build-system]
@@ -18,7 +22,8 @@ build-backend = "hatchling.build"
 
 [project.scripts]
 mlb-injury-server = "server:main"
+mlb-injury-http-server = "http_server:run_http_server"
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]
-include = ["scraper.py", "server.py"]
+include = ["scraper.py", "server.py", "http_server.py"]

--- a/server.py
+++ b/server.py
@@ -1,7 +1,8 @@
-"""FastMCP server for MLB injury data."""
+"""FastMCP server for MLB injury data with optional HTTP mode."""
 
 import asyncio
 import logging
+import sys
 from typing import List, Dict, Any
 from fastmcp import FastMCP
 from scraper import MLBInjuryScraper, InjuredPlayer
@@ -150,8 +151,27 @@ def search_player_injury(player_name: str, team: str = 'mets') -> Dict[str, Any]
         return {"error": f"Failed to search for player: {str(e)}"}
 
 def main():
-    """Run the MCP server."""
-    mcp.run()
+    """Run the MCP server or HTTP server based on command line arguments."""
+    if len(sys.argv) > 1 and sys.argv[1] == "--http":
+        # Run HTTP server
+        from http_server import run_http_server
+        
+        host = "0.0.0.0"
+        port = 8000
+        
+        # Parse additional arguments
+        for i, arg in enumerate(sys.argv[2:], 2):
+            if arg == "--host" and i + 1 < len(sys.argv):
+                host = sys.argv[i + 1]
+            elif arg == "--port" and i + 1 < len(sys.argv):
+                port = int(sys.argv[i + 1])
+        
+        logger.info(f"Starting HTTP server mode on {host}:{port}")
+        run_http_server(host=host, port=port)
+    else:
+        # Run traditional MCP server
+        logger.info("Starting MCP server mode")
+        mcp.run()
 
 if __name__ == "__main__":
     main()

--- a/uv.lock
+++ b/uv.lock
@@ -266,6 +266,20 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.118.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/3c/2b9345a6504e4055eaa490e0b41c10e338ad61d9aeaae41d97807873cdf2/fastapi-0.118.0.tar.gz", hash = "sha256:5e81654d98c4d2f53790a7d32d25a7353b30c81441be7d0958a26b5d761fa1c8", size = 310536 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/54e2bdaad22ca91a59455251998d43094d5c3d3567c52c7c04774b3f43f2/fastapi-0.118.0-py3-none-any.whl", hash = "sha256:705137a61e2ef71019d2445b123aa8845bd97273c395b744d5a7dfe559056855", size = 97694 },
+]
+
+[[package]]
 name = "fastmcp"
 version = "2.11.3"
 source = { registry = "https://pypi.org/simple" }
@@ -535,20 +549,28 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "fastapi" },
     { name = "fastmcp" },
+    { name = "httpx" },
     { name = "lxml" },
     { name = "pydantic" },
     { name = "requests" },
+    { name = "sse-starlette" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "fastapi", specifier = ">=0.104.0" },
     { name = "fastmcp", specifier = ">=0.1.0" },
+    { name = "httpx", specifier = ">=0.25.0" },
     { name = "lxml", specifier = ">=4.9.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "requests", specifier = ">=2.31.0" },
+    { name = "sse-starlette", specifier = ">=1.6.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
+    { name = "uvicorn", specifier = ">=0.24.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Create http_server.py with FastAPI-based REST API
- Add Server-Sent Events (SSE) endpoint for real-time updates
- Update server.py to support both MCP and HTTP modes via --http flag
- Add comprehensive HTTP API endpoints:
  * GET /api/teams - List all available teams
  * GET /api/teams/{team}/injuries - Get team injuries
  * GET /api/teams/{team}/summary - Get injury summary
  * GET /api/teams/{team}/players/{player_name} - Search player
  * GET /api/teams/{team}/injuries/stream - SSE real-time updates
- Add interactive API documentation at /docs (Swagger UI)
- Add CORS support for web applications
- Update Dockerfile to run HTTP server by default
- Add HTTP client example with Python code
- Update documentation with API usage examples (curl, Python, JavaScript)
- Add dependencies: fastapi, uvicorn, sse-starlette, httpx
- Tested all endpoints successfully with real data

This enables running the scraper as a web service without local code execution