### PR TITLE
Feature/mcp http sse transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,8 @@ RUN chown -R appuser:appuser /app
 # Switch to non-root user
 USER appuser
 
-# Expose port for HTTP server
+# Expose port for MCP HTTP/SSE server
 EXPOSE 8000
 
-# Health check for HTTP mode
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import requests; requests.get('http://localhost:8000/health', timeout=5)" || exit 1
-
-# Default to HTTP server mode, but allow override
-CMD ["python", "server.py", "--http"]
+# Default to MCP over HTTP/SSE transport, but allow override  
+CMD ["python", "server.py", "--sse"]

--- a/README.md
+++ b/README.md
@@ -128,30 +128,6 @@ The HTTP/SSE transport allows MCP clients to connect to the server over HTTP, ma
 
 ### Connecting MCP Clients
 
-#### Python MCP Client:
-```python
-import asyncio
-import httpx
-from mcp.client.sse import sse_client
-from mcp import ClientSession
-
-async def connect_to_mlb_server():
-    async with httpx.AsyncClient() as client:
-        async with sse_client("http://localhost:8000/sse") as (read, write):
-            async with ClientSession(read, write) as session:
-                # Initialize connection
-                await session.initialize()
-                
-                # List available tools
-                tools = await session.list_tools()
-                
-                # Call a tool
-                result = await session.call_tool("get_team_injuries", {"team": "mets"})
-                return result
-
-asyncio.run(connect_to_mlb_server())
-```
-
 #### Claude Desktop Configuration (HTTP/SSE):
 ```json
 {
@@ -163,110 +139,7 @@ asyncio.run(connect_to_mlb_server())
 }
 ```
 
-**Note**: The HTTP/SSE transport uses the standard MCP protocol, so all MCP tools work identically to stdio mode.
-
-### Additional REST API (Optional)
-
-In addition to the MCP protocol, a standalone REST API server is also available in `http_server.py` for non-MCP integrations:
-
-```bash
-# Run standalone REST API (not MCP-compatible)
-uv run mlb-injury-http-server
-```
-
-This provides standard REST endpoints at:
-- `GET /api/teams` - List all teams
-- `GET /api/teams/{team}/injuries` - Get team injuries
-- `GET /api/teams/{team}/summary` - Injury summary
-- `GET /api/teams/{team}/players/{player_name}` - Search player
-- `GET /docs` - Interactive API documentation
-
-**Note**: The REST API and MCP server are separate services. Use MCP HTTP/SSE transport for MCP client compatibility.
-
-### Example API Usage
-
-#### Using curl:
-```bash
-# Get available teams
-curl http://localhost:8000/api/teams
-
-# Get Dodgers injuries
-curl http://localhost:8000/api/teams/dodgers/injuries
-
-# Get Yankees injury summary
-curl http://localhost:8000/api/teams/yankees/summary
-
-# Search for a player
-curl http://localhost:8000/api/teams/mets/players/Pete
-
-# Stream real-time updates (SSE)
-curl -N http://localhost:8000/api/teams/mets/injuries/stream?interval=30
-```
-
-#### Using Python:
-```python
-import requests
-
-# Basic API client
-base_url = "http://localhost:8000"
-
-# Get teams
-teams = requests.get(f"{base_url}/api/teams").json()
-print(f"Available teams: {teams['total_teams']}")
-
-# Get team injuries
-injuries = requests.get(f"{base_url}/api/teams/mets/injuries").json()
-print(f"Mets injuries: {injuries['total_injured']}")
-
-# For SSE streaming, see examples/http_client_example.py
-```
-
-#### Using JavaScript:
-```javascript
-// Fetch team data
-const response = await fetch('http://localhost:8000/api/teams/dodgers/injuries');
-const data = await response.json();
-console.log(`${data.team_name} has ${data.total_injured} injured players`);
-
-// Server-Sent Events for real-time updates
-const eventSource = new EventSource('http://localhost:8000/api/teams/mets/injuries/stream?interval=30');
-eventSource.onmessage = function(event) {
-    const data = JSON.parse(event.data);
-    console.log('Injury update:', data);
-};
-```
-
-### Response Formats
-
-All endpoints return JSON responses with consistent structure:
-
-```json
-{
-  "team": "mets",
-  "team_name": "New York Mets", 
-  "total_injured": 5,
-  "players": [
-    {
-      "name": "Player Name",
-      "position": "RHP",
-      "injury": "Right elbow strain",
-      "il_date": "June 15 (15-day IL)",
-      "expected_return": "Late July",
-      "status": "Progressing well in rehab",
-      "last_updated": "July 10"
-    }
-  ]
-}
-```
-
-### Running the HTTP Server
-
-The HTTP server runs on port 8000 by default and provides:
-- **REST API endpoints** for programmatic access
-- **Server-Sent Events (SSE)** for real-time streaming
-- **Interactive documentation** at `/docs`
-- **CORS support** for web applications
-- **Health checks** for monitoring
+**Note**: The HTTP/SSE transport uses the standard MCP protocol, so all MCP tools work identically to stdio mode. See `examples/mcp_http_client_example.py` for programmatic client usage.
 
 ### MCP Tools Available
 

--- a/README.md
+++ b/README.md
@@ -58,37 +58,37 @@ uv run python scripts/test_scraper.py
 
 #### Local Development
 ```bash
-# Traditional MCP server (for AI tools)
+# Traditional MCP server with stdio transport (for local AI tools)
 uv run mlb-injury-server
 
-# HTTP/REST API server (for web applications)
-uv run python server.py --http
+# MCP server with HTTP/SSE transport (for remote/web-based MCP clients)
+uv run python server.py --sse
 
-# Or use the dedicated HTTP server script
-uv run mlb-injury-http-server
+# Or specify custom host/port
+uv run python server.py --sse --host 0.0.0.0 --port 8000
 ```
 
 #### Using Docker
 
-**Pull and run the pre-built image (HTTP mode by default):**
+**Pull and run the pre-built image (MCP HTTP/SSE by default):**
 ```bash
 docker run -p 8000:8000 ghcr.io/yourusername/mlb-injury-scraper:latest
 ```
 
-**Run in MCP mode:**
+**Run in stdio mode (for local integration):**
 ```bash
 docker run -it ghcr.io/yourusername/mlb-injury-scraper:latest python server.py
 ```
 
-**Build and run locally (HTTP mode):**
+**Build and run locally:**
 ```bash
 # Build the image
 docker build -t mlb-injury-scraper .
 
-# Run the container (HTTP server)
+# Run with HTTP/SSE transport (default)
 docker run -p 8000:8000 mlb-injury-scraper
 
-# Run in MCP mode
+# Run with stdio transport
 docker run -it mlb-injury-scraper python server.py
 ```
 
@@ -109,32 +109,79 @@ Then run:
 docker-compose up -d
 ```
 
-## HTTP/REST API
+## MCP Over HTTP/SSE Transport
 
-The application now supports both traditional MCP integration and HTTP/REST API access, making it usable without local code execution.
+The MCP server supports two transport protocols:
 
-### API Endpoints
+1. **stdio transport** (default): Traditional MCP over standard input/output for local AI tools
+2. **HTTP/SSE transport** (`--sse` flag): MCP protocol over HTTP with Server-Sent Events for remote access
 
-**Base URL**: `http://localhost:8000` (when running locally)
+### Using HTTP/SSE Transport
 
-#### Core Endpoints
+The HTTP/SSE transport allows MCP clients to connect to the server over HTTP, making it accessible without local code execution. This is perfect for:
+- Web-based MCP clients
+- Remote deployments
+- Cloud-hosted AI services
+- Docker containers
 
-- **Health Check**: `GET /health`
-- **API Info**: `GET /` (returns endpoint documentation)
-- **Interactive Docs**: `GET /docs` (Swagger UI)
-- **OpenAPI Schema**: `GET /openapi.json`
+**MCP Endpoint**: `http://localhost:8000/sse`
 
-#### Team Data Endpoints
+### Connecting MCP Clients
 
-- **Available Teams**: `GET /api/teams`
-- **Team Injuries**: `GET /api/teams/{team}/injuries`
-- **Injury Summary**: `GET /api/teams/{team}/summary`
-- **Player Search**: `GET /api/teams/{team}/players/{player_name}`
-- **Real-time Stream**: `GET /api/teams/{team}/injuries/stream?interval={seconds}`
+#### Python MCP Client:
+```python
+import asyncio
+import httpx
+from mcp.client.sse import sse_client
+from mcp import ClientSession
 
-#### Legacy Endpoints
+async def connect_to_mlb_server():
+    async with httpx.AsyncClient() as client:
+        async with sse_client("http://localhost:8000/sse") as (read, write):
+            async with ClientSession(read, write) as session:
+                # Initialize connection
+                await session.initialize()
+                
+                # List available tools
+                tools = await session.list_tools()
+                
+                # Call a tool
+                result = await session.call_tool("get_team_injuries", {"team": "mets"})
+                return result
 
-- **Mets Injuries**: `GET /api/mets/injuries` (redirects to `/api/teams/mets/injuries`)
+asyncio.run(connect_to_mlb_server())
+```
+
+#### Claude Desktop Configuration (HTTP/SSE):
+```json
+{
+  "mcpServers": {
+    "mlb-injury-scraper": {
+      "url": "http://localhost:8000/sse"
+    }
+  }
+}
+```
+
+**Note**: The HTTP/SSE transport uses the standard MCP protocol, so all MCP tools work identically to stdio mode.
+
+### Additional REST API (Optional)
+
+In addition to the MCP protocol, a standalone REST API server is also available in `http_server.py` for non-MCP integrations:
+
+```bash
+# Run standalone REST API (not MCP-compatible)
+uv run mlb-injury-http-server
+```
+
+This provides standard REST endpoints at:
+- `GET /api/teams` - List all teams
+- `GET /api/teams/{team}/injuries` - Get team injuries
+- `GET /api/teams/{team}/summary` - Injury summary
+- `GET /api/teams/{team}/players/{player_name}` - Search player
+- `GET /docs` - Interactive API documentation
+
+**Note**: The REST API and MCP server are separate services. Use MCP HTTP/SSE transport for MCP client compatibility.
 
 ### Example API Usage
 

--- a/examples/mcp_http_client_example.py
+++ b/examples/mcp_http_client_example.py
@@ -1,0 +1,45 @@
+"""Example MCP client using HTTP/SSE transport."""
+
+import asyncio
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# For HTTP/SSE transport
+import httpx
+from mcp.client.sse import sse_client
+
+async def test_mcp_http():
+    """Test MCP server over HTTP/SSE transport."""
+    print("🔗 Testing MCP server over HTTP/SSE transport...")
+    
+    async with httpx.AsyncClient() as client:
+        async with sse_client("http://localhost:8000/sse") as (read, write):
+            async with ClientSession(read, write) as session:
+                # Initialize the connection
+                await session.initialize()
+                
+                # List available tools
+                tools = await session.list_tools()
+                print(f"\n📋 Available tools: {len(tools.tools)}")
+                for tool in tools.tools:
+                    print(f"   - {tool.name}: {tool.description}")
+                
+                # Test get_available_teams
+                print("\n🏟️  Testing get_available_teams...")
+                result = await session.call_tool("get_available_teams", {})
+                print(f"   Result: {result.content[0].text[:200]}...")
+                
+                # Test get_team_injuries
+                print("\n⚕️  Testing get_team_injuries for Mets...")
+                result = await session.call_tool("get_team_injuries", {"team": "mets"})
+                print(f"   Result: {result.content[0].text[:200]}...")
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(test_mcp_http())
+        print("\n✅ MCP HTTP/SSE transport test successful!")
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+

--- a/server.py
+++ b/server.py
@@ -151,26 +151,31 @@ def search_player_injury(player_name: str, team: str = 'mets') -> Dict[str, Any]
         return {"error": f"Failed to search for player: {str(e)}"}
 
 def main():
-    """Run the MCP server or HTTP server based on command line arguments."""
-    if len(sys.argv) > 1 and sys.argv[1] == "--http":
-        # Run HTTP server
-        from http_server import run_http_server
-        
-        host = "0.0.0.0"
-        port = 8000
-        
-        # Parse additional arguments
-        for i, arg in enumerate(sys.argv[2:], 2):
-            if arg == "--host" and i + 1 < len(sys.argv):
-                host = sys.argv[i + 1]
-            elif arg == "--port" and i + 1 < len(sys.argv):
-                port = int(sys.argv[i + 1])
-        
-        logger.info(f"Starting HTTP server mode on {host}:{port}")
-        run_http_server(host=host, port=port)
+    """Run the MCP server with configurable transport (stdio or HTTP/SSE)."""
+    # Default values
+    transport = "stdio"
+    host = "0.0.0.0"
+    port = 8000
+    
+    # Parse command line arguments
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "--http" or sys.argv[1] == "--sse":
+            transport = "sse"  # FastMCP uses 'sse' for HTTP/SSE transport
+            
+            # Parse additional arguments
+            for i, arg in enumerate(sys.argv[2:], 2):
+                if arg == "--host" and i + 1 < len(sys.argv):
+                    host = sys.argv[i + 1]
+                elif arg == "--port" and i + 1 < len(sys.argv):
+                    port = int(sys.argv[i + 1])
+    
+    # Run MCP server with specified transport
+    if transport == "sse":
+        logger.info(f"Starting MCP server with HTTP/SSE transport on {host}:{port}")
+        logger.info(f"MCP endpoint will be available at: http://{host}:{port}/sse")
+        mcp.run(transport="sse", host=host, port=port)
     else:
-        # Run traditional MCP server
-        logger.info("Starting MCP server mode")
+        logger.info("Starting MCP server with stdio transport")
         mcp.run()
 
 if __name__ == "__main__":


### PR DESCRIPTION
feat: Add proper MCP over HTTP/SSE transport support
- Update server.py to use FastMCP's native SSE transport
- Add --sse flag to enable HTTP/SSE transport (vs stdio)
- MCP endpoint available at http://localhost:8000/sse
- Maintain backward compatibility with stdio transport (default)
- Update Dockerfile to use SSE transport by default
- Add MCP client example demonstrating HTTP/SSE usage
- Update documentation to clarify MCP vs REST API
- Tested successfully with MCP client over HTTP/SSE

This enables MCP clients to connect remotely without local code execution,
while maintaining full MCP protocol compatibility.

docs: Clean up README to focus on MCP server only
- Remove REST API examples (curl, Python, JavaScript)
- Remove REST API endpoint documentation
- Keep only MCP transport configuration
- Simplify to stdio/SSE/HTTP transport options
- Reference example files for programmatic usage